### PR TITLE
Improve docstrings in the Lumi package

### DIFF
--- a/lumi/__init__.py
+++ b/lumi/__init__.py
@@ -1,5 +1,7 @@
 """
-Import main classes and functions from the lumi package
+Lumi is a nano framework to convert your python functions
+into a REST API without any extra headache.
 """
+
 from lumi.api import Lumi
 from lumi.enums import RequestMethod

--- a/lumi/server.py
+++ b/lumi/server.py
@@ -1,8 +1,8 @@
 import gunicorn.app.base
 
 '''
-Development sever for RPC
-In production, use gunicorn daemon to manage the server
+Development server for RPC
+In production, use gunicorn daemon to manage the server.
 '''
 class DevelopmentServer(gunicorn.app.base.BaseApplication):
     def __init__(self, app, options=None):


### PR DESCRIPTION
The docstring contained in the "header" in `lumi/__init__.py` is used for package presentation normally.

And it is also shown when using the `help()` function:
```python
>>> import lumi
>>> help(lumi)
Help on package lumi: 

NAME
    lumi - Import main classes and functions from the lumi package

PACKAGE CONTENTS
    api
    enums
    server
{...}
```

Now:
```python
>>> import lumi
>>> help(lumi)
Help on package lumi: 

NAME
    lumi - Lumi is a nano framework to convert your python functions
           into a REST API without any extra headache.

PACKAGE CONTENTS
    api
    enums
    server
{...}
```

